### PR TITLE
fix for issue #3

### DIFF
--- a/netmri_bootstrap/__init__.py
+++ b/netmri_bootstrap/__init__.py
@@ -122,7 +122,7 @@ class Bootstrapper:
                     continue
                 api_objects[api_item.id] = api_item
 
-            for git_item in self.repo.object_index[klass.__name__].values():
+            for git_item in self.repo.object_index.get(klass.__name__, {}).values():
                 if git_item["id"] is None:
                     logger.debug(f"Skipping {klass.__name__} \"{git_item['path']}\" because it doesn't have id assigned (not synced to netmri yet?)")
                     continue


### PR DESCRIPTION
There is a fix for issue #3. The error appears, when  parameter ` "skip_readonly_objects": true`  in config file and all files in directory are read-only, therefore directory is empty and there is no such key in `self.repo.object_index`. No such key means this object is None and it is impossible to get values. 
Solution: if there is no key, it will return empty object {} by default instead of None.