### PR TITLE
fix 'str' object has no attribute '__module__' on push

### DIFF
--- a/netmri_bootstrap/objects/api.py
+++ b/netmri_bootstrap/objects/api.py
@@ -88,9 +88,9 @@ class ApiObject():
     @classmethod
     def _get_subclass_by_path(cls, path):
         subclass_name = None
-        for cls, cls_path in config.get_config().class_paths.items():
+        for kls, cls_path in config.get_config().class_paths.items():
             if path.startswith(cls_path):
-                subclass_name = cls
+                subclass_name = kls
                 break
 
         the_module = importlib.import_module(cls.__module__)


### PR DESCRIPTION
verified on my own setup. error disappeared after the fix, script completed successfully

```
$ ./netmri-bootstrap.py push
self.repo.heads [<git.Head "refs/heads/master">]
DEL Script "aaaa.py" [scripts/aaaa.py]
scripts/aaaa.py wasn't found on server, ignoring
scripts/foo.pl -> Script "foo-test" (id 47))
```
